### PR TITLE
Add Rage break event (untested)

### DIFF
--- a/src/me/badbones69/crazyenchantments/api/events/RageBreakEvent.java
+++ b/src/me/badbones69/crazyenchantments/api/events/RageBreakEvent.java
@@ -1,0 +1,68 @@
+package me.badbones69.crazyenchantments.api.events;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class RageBreakEvent extends Event implements Cancellable {
+	
+	private Player Player;
+	private Entity Damager;
+	private ItemStack It;
+	private Boolean Cancel;
+	
+	public RageBreakEvent(Player player, Entity damager, ItemStack item) {
+		Player = player;
+		Damager = damager;
+		It = item;
+		Cancel = false;
+	}
+	
+	/**
+	 * 
+	 * @return The player that uses the enchantment.
+	 */
+	public Player getPlayer() {
+		return Player;
+	}
+	
+	/**
+	 * 
+	 * @return The entity that is attacking the player.
+	 */
+	public Entity getDamager() {
+		return Damager;
+	}
+	
+	/**
+	 * 
+	 * @return The item that uses the enchantment.
+	 */
+	public ItemStack getItem() {
+		return It;
+	}
+	
+	private static final HandlerList handlers = new HandlerList();
+	
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+	
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+	
+	@Override
+	public boolean isCancelled() {
+		return Cancel;
+	}
+	
+	@Override
+	public void setCancelled(boolean cancel) {
+		Cancel = cancel;
+	}
+	
+}

--- a/src/me/badbones69/crazyenchantments/enchantments/Swords.java
+++ b/src/me/badbones69/crazyenchantments/enchantments/Swords.java
@@ -26,6 +26,7 @@ import me.badbones69.crazyenchantments.api.CEnchantments;
 import me.badbones69.crazyenchantments.api.DataStorage;
 import me.badbones69.crazyenchantments.api.currencyapi.Currency;
 import me.badbones69.crazyenchantments.api.currencyapi.CurrencyAPI;
+import me.badbones69.crazyenchantments.api.events.RageBreakEvent;
 import me.badbones69.crazyenchantments.api.events.DisarmerUseEvent;
 import me.badbones69.crazyenchantments.api.events.EnchantmentUseEvent;
 import me.badbones69.crazyenchantments.multisupport.SpartanSupport;
@@ -45,18 +46,23 @@ public class Swords implements Listener {
 			if(!Support.isFriendly(e.getDamager(), e.getEntity())) {
 				if(DataStorage.isBreakRageOnDamageOn()) {
 					if(e.getEntity() instanceof Player) {
-						UUID uuid = e.getEntity().getUniqueId();
-						if(multiplier.containsKey(uuid)) {
-							inRage.get(uuid).cancel();
-							multiplier.remove(uuid);
-							rageLevel.remove(uuid);
-							inRage.remove(uuid);
-							if(Main.settings.getMessages().contains("Messages.Rage.Damaged")) {
-								if(Main.settings.getMessages().getString("Messages.Rage.Damaged").length() > 0) {
-									e.getEntity().sendMessage(Methods.color(Main.settings.getMessages().getString("Messages.Rage.Damaged")));
+						Player player = (Player)e.getEntity();
+						RageBreakEvent event = new RageBreakEvent(player, e.getDamager(), Methods.getItemInHand(player));
+						Bukkit.getPluginManager().callEvent(event);
+						if(!event.isCancelled()) {
+							UUID uuid = e.getEntity().getUniqueId();
+							if(multiplier.containsKey(uuid)) {
+								inRage.get(uuid).cancel();
+								multiplier.remove(uuid);
+								rageLevel.remove(uuid);
+								inRage.remove(uuid);
+								if(Main.settings.getMessages().contains("Messages.Rage.Damaged")) {
+									if(Main.settings.getMessages().getString("Messages.Rage.Damaged").length() > 0) {
+										e.getEntity().sendMessage(Methods.color(Main.settings.getMessages().getString("Messages.Rage.Damaged")));
+									}
+								}else {
+									e.getEntity().sendMessage(Methods.color("&7[&c&lRage&7]: &cYou have been hurt and it broke your Rage Multiplier!"));
 								}
-							}else {
-								e.getEntity().sendMessage(Methods.color("&7[&c&lRage&7]: &cYou have been hurt and it broke your Rage Multiplier!"));
 							}
 						}
 					}


### PR DESCRIPTION
This should work to address my request at #254 although "getItemInHand" might not return the correct item if Rage is broken after the player has switched weapons, in the use case I've described in the issue knowing what the item is isn't required, so the "item" part in the event could be removed.